### PR TITLE
modifying legacy_switch and itemset_spec to get tests to pass

### DIFF
--- a/lib/vayacondios/legacy_switch.rb
+++ b/lib/vayacondios/legacy_switch.rb
@@ -5,13 +5,17 @@ class Vayacondios
   class StandardContentsHandler
     def wrap_contents(contents) {contents: contents} end
     def extract_contents(document) document['contents'] end
-    def proper_request(document) document.is_a? Hash end
+    def proper_request(document)
+      document.is_a? Hash and document.fetch('_json', {}).is_a? Hash
+    end
   end
-  
+
   class LegacyContentsHandler
     def wrap_contents(contents) contents end
-    def extract_contents(document) document end
-    def proper_request(document) document.is_a? Array end
+    def extract_contents(document) document.fetch('_json', {}) end
+    def proper_request(document)
+      document.is_a? Array or document.fetch('_json', {}).is_a? Array
+    end
   end
 
   def self.legacy_switch

--- a/spec/server/itemset_legacy_spec.rb
+++ b/spec/server/itemset_legacy_spec.rb
@@ -11,38 +11,39 @@ describe HttpShim do
 
   context 'Basic requirements' do
     it 'requires a topic' do
+      Vayacondios.force_legacy_mode(true)
       with_api(HttpShim) do |api|
         put_request({
           :path => '/v1/infochimps/itemset/',
-          :body => MultiJson.dump({:contents =>["foo"]}),
+          :body => MultiJson.dump(["foo"]),
           :head => { :content_type => 'application/json' }
         }, err) do |c|
           c.response_header.status.should == 400
         end
       end
     end
-    
+
     it 'requires an id' do
       with_api(HttpShim) do |api|
         put_request({
           :path => '/v1/infochimps/itemset/power',
-          :body => MultiJson.dump({:contents =>["foo"]}),
+          :body => MultiJson.dump(["foo"]),
           :head => { :content_type => 'application/json' }
         }, err) do |c|
           c.response_header.status.should == 400
         end
-  
+
         get_mongo_db do |db|
           db.collection("infochimps.power.itemset").find_one().should be_nil
         end
       end
     end
-    
+
     it 'rejects deep IDs' do
       with_api(HttpShim) do |api|
         put_request({
           :path => '/v1/infochimps/itemset/power/level/is/invalid',
-          :body => MultiJson.dump({:contents =>["foo"]}),
+          :body => MultiJson.dump(["foo"]),
           :head => { :content_type => 'application/json' }
         }, err) do |c|
           c.response_header.status.should == 400
@@ -55,118 +56,38 @@ describe HttpShim do
     end
   end
 
-  context 'handles PUT requests' do
-    it 'only accepts hashes' do
-      # note: due to unknown class variable handling by rspec,
-      # force_legacy_mode must be set inside the it block to
-      # get all tests to pass at once
-      Vayacondios.force_legacy_mode(false)
-      with_api(HttpShim) do |api|
-        put_request({
-          :path => '/v1/infochimps/itemset/power/level',
-          :body => MultiJson.dump(['foo', 'bar']),
-          :head => { :content_type => 'application/json' }
-        }, err) do |c|
-          c.response_header.status.should == 400 # geometrid: changed from 500
-        end
 
-        get_mongo_db do |db|
-          db.collection("infochimps.itemset").find_one({:_id => "power"}).should be_nil
-        end
-      end
-      with_api(HttpShim) do |api|
-        put_request({
-          :path => '/v1/infochimps/itemset/power/level',
-          :body => "foo",
-          :head => { :content_type => 'application/json' }
-        }, err) do |c|
-          c.response_header.status.should == 400
-        end
-        
-        get_mongo_db do |db|
-          db.collection("infochimps.itemset").find_one({:_id => "power"}).should be_nil
-        end
-      end
-    end
-    
-    it "stores the array when the resource doesn't exist" do
-      with_api(HttpShim) do |api|
-        put_request({
-          :path => '/v1/infochimps/itemset/power/level',
-          :body => MultiJson.dump({:contents =>["foo", "bar"]}),
-          :head => { :content_type => 'application/json' }
-        }, err) do |c|
-          c.response_header.status.should == 200 # TODO Make this 201 Created
-          c.response.should eql ""
-        end
-        
-        get_mongo_db do |db|
-          db.collection("infochimps.power.itemset").find_one({:_id => "level"})["d"].should eql ["foo", "bar"]
-        end
-      end
-    end
-    
-    it "clobbers the previous array when the resource does exist" do
-      with_api(HttpShim) do |api|
-        put_request({
-          :path => '/v1/infochimps/itemset/power/level',
-          :body => MultiJson.dump({:contents =>["chimpanzee", "bonobo"]}),
-          :head => { :content_type => 'application/json' }
-        }, err) do |c|
-          c.response_header.status.should == 200 # TODO Make this 204 No content
-          c.response.should eql ""
-        end
-      end
-      
-      # Verify the first was created
-      get_mongo_db do |db|
-        db.collection("infochimps.power.itemset").find_one({:_id => "level"})["d"].should eql ["chimpanzee", "bonobo"]
-      end
-      
-      with_api(HttpShim) do |api|
-        put_request({
-          :path => '/v1/infochimps/itemset/power/level',
-          :body => MultiJson.dump({:contents =>["foo", "bar"]}),
-          :head => { :content_type => 'application/json' }
-        }, err) do |c|
-          c.response_header.status.should == 200
-          c.response.should eql ""
-        end
-        
-        # Verify the first was clobbered
-        get_mongo_db do |db|
-          db.collection("infochimps.power.itemset").find_one({:_id => "level"})["d"].should eql ["foo", "bar"]
-        end
-      end
-    end
-  end
-  
   context 'can handle GET requests' do
+      Vayacondios.force_legacy_mode(true)
+
     it 'and return 404 for missing resources' do
       with_api(HttpShim) do |api|
+      Vayacondios.force_legacy_mode(true)
+
         get_request({:path => '/v1/infochimps/itemset/missing/resource'}, err) do |c|
           c.response_header.status.should == 404
         end
       end
     end
-    
+
     it 'and return an array for valid resources' do
+
       with_api(HttpShim) do |api|
         put_request({
           :path => '/v1/infochimps/itemset/power/level',
-          :body => MultiJson.dump({:contents =>["foo", "bar"]}),
+          :body => MultiJson.dump(["foo", "bar"]),
           :head => { :content_type => 'application/json' }
         }, err)
       end
       with_api(HttpShim) do |api|
         get_request({:path => '/v1/infochimps/itemset/power/level'}, err) do |c|
-          c.response_header.status.should == 200 
-          MultiJson.load(c.response).should eql({"contents" => ["foo", "bar"]})
+          c.response_header.status.should == 200
+          MultiJson.load(c.response).should eql(["foo", "bar"])
         end
       end
     end
   end
-  
+
   context "will not handle POST requests" do
     it 'fails on POST' do
       with_api(HttpShim) do |api|
@@ -182,30 +103,112 @@ describe HttpShim do
     end
   end
 
-  context "handles PATCH requests" do
+  context 'handles PUT requests in legacy mode' do
+    Vayacondios.force_legacy_mode(true)
+    it 'only accepts arrays' do
+      with_api(HttpShim) do |api|
+        put_request({
+                      :path => '/v1/infochimps/itemset/power/level',
+                      :body => MultiJson.dump({'foo' => 'bar'}),
+                      :head => { :content_type => 'application/json' }
+                    }, err) do |c|
+          c.response_header.status.should == 400  # geometrid: changed from 500
+        end
+
+        get_mongo_db do |db|
+          db.collection("infochimps.itemset").find_one({:_id => "power"}).should be_nil
+        end
+      end
+      with_api(HttpShim) do |api|
+        put_request({
+                      :path => '/v1/infochimps/itemset/power/level',
+                      :body => "foo",
+                      :head => { :content_type => 'application/json' }
+                    }, err) do |c|
+          c.response_header.status.should == 400
+        end
+
+        get_mongo_db do |db|
+          db.collection("infochimps.itemset").find_one({:_id => "power"}).should be_nil
+        end
+      end
+    end
+    it "stores the array when the resource doesn't exist" do
+      with_api(HttpShim) do |api|
+        put_request({
+          :path => '/v1/infochimps/itemset/power/level',
+          :body => MultiJson.dump(["foo", "bar"]),
+          :head => { :content_type => 'application/json' }
+        }, err) do |c|
+          c.response_header.status.should == 200 # TODO Make this 201 Created
+          c.response.should eql ""
+        end
+
+        get_mongo_db do |db|
+          db.collection("infochimps.power.itemset").find_one({:_id => "level"})["d"].should eql ["foo", "bar"]
+        end
+      end
+    end
+    it "clobbers the previous array when the resource does exist" do
+      with_api(HttpShim) do |api|
+        put_request({
+          :path => '/v1/infochimps/itemset/power/level',
+          :body => MultiJson.dump(["chimpanzee", "bonobo"]),
+          :head => { :content_type => 'application/json' }
+        }, err) do |c|
+          c.response_header.status.should == 200 # TODO Make this 204 No content
+          c.response.should eql ""
+        end
+      end
+
+      # Verify the first was created
+      get_mongo_db do |db|
+        db.collection("infochimps.power.itemset").find_one({:_id => "level"})["d"].should eql ["chimpanzee", "bonobo"]
+      end
+
+      with_api(HttpShim) do |api|
+        put_request({
+          :path => '/v1/infochimps/itemset/power/level',
+          :body => MultiJson.dump(["foo", "bar"]),
+          :head => { :content_type => 'application/json' }
+        }, err) do |c|
+          c.response_header.status.should == 200
+          c.response.should eql ""
+        end
+
+        # Verify the first was clobbered
+        get_mongo_db do |db|
+          db.collection("infochimps.power.itemset").find_one({:_id => "level"})["d"].should eql ["foo", "bar"]
+        end
+      end
+    end
+  end
+
+  context "handles PATCH requests in legacy mode" do
+    Vayacondios.force_legacy_mode(true)
     it 'creates a missing resource' do
       with_api(HttpShim) do |api|
         put_request({
           :path => '/v1/infochimps/itemset/power/level',
           :head => ({'X-Method' => 'PATCH', :content_type => 'application/json' }),
-          :body => MultiJson.dump({:contents =>["bar"]})
+          :body => MultiJson.dump(["bar"])
         }, err) do |c|
           c.response_header.status.should eql 200 # TODO Make this 201 Created
           c.response.should eql ""
         end
-        
+
         # Verify the resource was created
         get_mongo_db do |db|
           db.collection("infochimps.power.itemset").find_one({:_id => "level"})["d"].should eql ["bar"]
         end
       end
     end
-    
+
     it 'merges with PATCH' do
       with_api(HttpShim) do |api|
         put_request({
           :path => '/v1/infochimps/itemset/merge/test',
-          :body => MultiJson.dump({:contents =>["foo"]}),
+          :body => MultiJson.dump(["foo"]),
           :head => { :content_type => 'application/json' }
         }, err)
       end
@@ -213,37 +216,37 @@ describe HttpShim do
         put_request({
           :path => '/v1/infochimps/itemset/merge/test',
           :head => ({'X-Method' => 'PATCH', :content_type => 'application/json' }),
-          :body => MultiJson.dump({:contents =>["bar"]})
+          :body => MultiJson.dump(["bar"])
         }, err)
       end
       with_api(HttpShim) do |api|
         get_request({:path => '/v1/infochimps/itemset/merge/test'}, err) do |c|
           c.response_header.status.should == 200
-          MultiJson.load(c.response).should eql({"contents" => ["foo", "bar"]})
+          MultiJson.load(c.response).should eql(["foo", "bar"])
         end
       end
     end
   end
-  
-  context "will handle DELETE requests" do
-    Vayacondios.force_legacy_mode(false)
+
+  context "will handle DELETE requests in legacy mode" do
+    Vayacondios.force_legacy_mode(true)
     it 'will not delete a missing resource' do
       with_api(HttpShim) do |api|
         delete_request({
           :path => '/v1/infochimps/itemset/merge/test',
-          :body => MultiJson.dump({:contents =>["bar"]}),
+          :body => MultiJson.dump(["bar"]),
           :head => { :content_type => 'application/json' }
         }, err) do |c|
           c.response_header.status.should == 404
         end
       end
     end
-      
+
     it "will be ok to delete items that don't exist" do
       with_api(HttpShim) do |api|
         put_request({
           :path => '/v1/infochimps/itemset/power/level',
-          :body => MultiJson.dump({:contents =>["foo"]}),
+          :body => MultiJson.dump(["foo"]),
           :head => { :content_type => 'application/json' }
         }, err) do |c|
           c.response_header.status.should == 200 # TODO Make this 201 Created
@@ -252,19 +255,19 @@ describe HttpShim do
       with_api(HttpShim) do |api|
         delete_request({
           :path => '/v1/infochimps/itemset/power/level',
-          :body => MultiJson.dump({:contents =>["bar"]}),
+          :body => MultiJson.dump(["bar"]),
           :head => { :content_type => 'application/json' }
         }, err) do |c|
           c.response_header.status.should == 200 # TODO Make this 204 No content
         end
       end
     end
-    
+
     it "will delete items that do exist" do
       with_api(HttpShim) do |api|
         put_request({
           :path => '/v1/infochimps/itemset/power/level',
-          :body => MultiJson.dump({:contents =>["foo", "bar"]}),
+          :body => MultiJson.dump(["foo", "bar"]),
           :head => { :content_type => 'application/json' }
         }, err) do |c|
           c.response_header.status.should == 200 # TODO Makes this 201 Created
@@ -273,7 +276,7 @@ describe HttpShim do
       with_api(HttpShim) do |api|
         delete_request({
           :path => '/v1/infochimps/itemset/power/level',
-          :body => MultiJson.dump({:contents =>["bar"]}),
+          :body => MultiJson.dump(["bar"]),
           :head => { :content_type => 'application/json' }
         }, err) do |c|
           c.response_header.status.should == 200 # TODO Make this 204 No content
@@ -282,16 +285,16 @@ describe HttpShim do
       with_api(HttpShim) do |api|
         get_request({:path => '/v1/infochimps/itemset/power/level'}, err) do |c|
           c.response_header.status.should == 200
-          MultiJson.load(c.response).should eql({"contents" => ["foo"]})
+          MultiJson.load(c.response).should eql(["foo"])
         end
       end
     end
-    
+
     it "leaves behind an empty array if everything is deleted" do
       with_api(HttpShim) do |api|
         put_request({
           :path => '/v1/infochimps/itemset/power/level',
-          :body => MultiJson.dump({:contents =>["foo", "bar"]}),
+          :body => MultiJson.dump(["foo", "bar"]),
           :head => { :content_type => 'application/json' }
         }, err) do |c|
           c.response_header.status.should == 200 # TODO Makes this 201 Created
@@ -300,7 +303,7 @@ describe HttpShim do
       with_api(HttpShim) do |api|
         delete_request({
           :path => '/v1/infochimps/itemset/power/level',
-          :body => MultiJson.dump({:contents =>["foo", "bar"]}),
+          :body => MultiJson.dump(["foo", "bar"]),
           :head => { :content_type => 'application/json' }
         }, err) do |c|
           c.response_header.status.should == 200 # TODO Make this 204 No content
@@ -309,7 +312,7 @@ describe HttpShim do
       with_api(HttpShim) do |api|
         get_request({:path => '/v1/infochimps/itemset/power/level'}, err) do |c|
           c.response_header.status.should == 200
-          MultiJson.load(c.response).should eql({"contents" => []})
+          MultiJson.load(c.response).should eql([])
         end
       end
     end


### PR DESCRIPTION
Summary of changes:
- modified legacy_switch.rb to account for goliath's handling of non-hashes
- split itemset_spec.rb into two files, itemset_spec.rb and itemset_legacy_spec.rb, in order to better handle the Vayacondios.legacy_switch class variable when testing
